### PR TITLE
Englishify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 Tested on android and ios.
 
 
-Concept:  
-1) on startup copy all files from www to PERSISTENT storage. (if not be copy before);  
-2) download config.json from server.  
-3) check the version constants in downloaded config.json and local config.json.  
-4) if different - download new files from server to PERSISTENT, then override config.json.  
-(download not all files, only new\different which are written in config.json as new. I have Grunt script for calculate a list of new files.)  
+Concept:
+1) on startup copy all files from www to PERSISTENT storage. (if not copied before);
+2) download config.json from server.
+3) compare the version constants in downloaded config.json and local config.json.
+4) if different - download new files from server to PERSISTENT, then override local config.json.
+(download not all files, only new\different which are written in config.json as new. I have a Grunt script that calculates a list of new files.)
 5) redirect window.location.href to persistent storage + /$start_page.html;
 
 **Attention:**
-Current version required establish internet connection on app startup;  
-  
+Current version requires internet connection on app startup;  
+
   
  --------------------------------------------------------------------------------  
 ## Installation:
@@ -28,41 +28,39 @@ Current version required establish internet connection on app startup;
   cordova plugin add org.apache.cordova.dialogs
   cordova plugin add https://github.com/mnill/cordova-app-updater.git --variable SERVER_ADDRESS="$SERVER_URL"
 ```
-Replace $SERVER_URL with your server url, where your config.json and files for update. (example http://mnillstone.com/)
+Replace $SERVER_URL with your server url, where your config.json and files for update. (example http://mnillstone.com/) --- **Make sure to include the trailing slash in your url**
 
 **Attention:**  
-You must use my fork of cordova-plugin-file (https://github.com/mnill/cordova-plugin-file.git). Make sure your delete official plugin file before installation(if it's been installed before).   
-It's because official plugin does not support readonly access to file:///android_asset/ on android. Open pull-request: https://github.com/apache/cordova-plugin-file/pull/84
+You must use my fork of cordova-plugin-file (https://github.com/mnill/cordova-plugin-file.git). If you already have the official "cordova-plugin-file" plugin installed, delete it before installing my version.
+--- The official plugin does not support readonly access to file:///android_asset/ on android. Open pull-request: https://github.com/apache/cordova-plugin-file/pull/84
 
 **Set start page**
-Add ```<content src="updater.html"/>``` to your main config.xml, or design your own start updater page, like www/updater.html. I'm just use splashscreen plugin.
-  
+Add ```<content src="updater.html"/>``` to your main config.xml, or design your own start updater page, like www/updater.html. I just use a splashscreen plugin.
+
 ### Setup config.json
 Write a config.json to describe files to download and version. Put it in $SERVER_URL/config.json; (example http://mnillstone.com/config.json);
 
 **Structure**
 
-*don't forget to delete comment lines, must be valide json*
+*don't forget to delete comment lines, must be valid JSON*
 ```javascript
 {
-  "version": 1, //version, for check is update are required. default - 0
-  "start": "index.html", //start page of you app
-  "files": [  // these list of new or differents files to download
-    "index.html", //example. all files will be download from $SERVER_URL + this path.
+  "version": 1, //version, to see if an update is required. default - 0
+  "start": "index.html", //start page of your app
+  "files": [  // an array of new or different files to download
+    "index.html", //example. all files will be downloaded from $SERVER_URL/$this_path
     "image/fon.png" //example
   ]
 }
 ```
- 
+
 --------------------------------------------------------------------------------  
 ## Demo:
-Just use http://mnillstone.com/ for $SERVER_URL; On first launch app will download all files from my site, and only config.json at all other launches.
+Just use http://mnillstone.com/ for $SERVER_URL; On first launch the app will download all files from my site, and only config.json at all other launches.
 
  --------------------------------------------------------------------------------  
 ## Tips  
-1) If downloaded config.json verison is not equal to local config.json, updater just clean all cache, copy all files from www folder to cache, then download new files, then override config.json  
+1) If server config.json verison != local config.json version, the updater wipes the cache, copies all files from www folder to cache, downloads new files, and overrides config.json.
 
 --------------------------------------------------------------------------------  
-  
-  
-*Yes my english is fully ugly*  
+

--- a/README.md
+++ b/README.md
@@ -24,16 +24,12 @@ Current version requires internet connection on app startup;
 ### Setup Cordova:
 
 ```bash
-  cordova plugin add https://github.com/mnill/cordova-plugin-file.git
+  cordova plugin add org.apache.cordova.file
   cordova plugin add org.apache.cordova.file-transfer
   cordova plugin add org.apache.cordova.dialogs
   cordova plugin add https://github.com/mnill/cordova-app-updater.git --variable SERVER_ADDRESS="$SERVER_URL"
 ```
 Replace $SERVER_URL with your server url, where your config.json and files for update. (example http://mnillstone.com/) --- **Make sure to include the trailing slash in your url**
-
-**Attention:**  
-You must use my fork of cordova-plugin-file (https://github.com/mnill/cordova-plugin-file.git). If you already have the official "cordova-plugin-file" plugin installed, delete it before installing my version.
---- The official plugin does not support readonly access to file:///android_asset/ on android. Open pull-request: https://github.com/apache/cordova-plugin-file/pull/84
 
 **Set start page**
 Add ```<content src="updater.html"/>``` to your main config.xml, or design your own start updater page, like www/updater.html. I just use a splashscreen plugin.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,16 @@ Current version requires internet connection on app startup;
 ### Setup Cordova:
 
 ```bash
-  cordova plugin add org.apache.cordova.file
+  cordova plugin add https://github.com/mnill/cordova-plugin-file.git
   cordova plugin add org.apache.cordova.file-transfer
   cordova plugin add org.apache.cordova.dialogs
   cordova plugin add https://github.com/mnill/cordova-app-updater.git --variable SERVER_ADDRESS="$SERVER_URL"
 ```
 Replace $SERVER_URL with your server url, where your config.json and files for update. (example http://mnillstone.com/) --- **Make sure to include the trailing slash in your url**
+
+**Attention**
+You must use my fork of cordova-plugin-file (https://github.com/mnill/cordova-plugin-file.git). Make sure you delete the official plugin file before installing (if it's been installed before).
+It's because the official plugin does not support readonly access to file:///android_asset/ on android. See open pull-request: https://github.com/apache/cordova-plugin-file/pull/84
 
 **Set start page**
 Add ```<content src="updater.html"/>``` to your main config.xml, or design your own start updater page, like www/updater.html. I just use a splashscreen plugin.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Write a config.json to describe files to download and version. Put it in $SERVER
   "files": [  // these list of new or differents files to download
     "index.html", //example. all files will be download from $SERVER_URL + this path.
     "image/fon.png" //example
-  ],
+  ]
 }
 ```
  

--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@ Tested on android and ios.
 
 
 Concept:
-1) on startup copy all files from www to PERSISTENT storage. (if not copied before);
 
-2) download config.json from server.
-
-3) compare the version constants in downloaded config.json and local config.json.
-4) if different - download new files from server to PERSISTENT, then override local config.json.
+1. on startup copy all files from www to PERSISTENT storage. (if not copied before);
+2. download config.json from server.
+3. compare the version constants in downloaded config.json and local config.json.
+4. if different - download new files from server to PERSISTENT, then override local config.json.
 (download not all files, only new\different which are written in config.json as new. I have a Grunt script that calculates a list of new files.)
-5) redirect window.location.href to persistent storage + /$start_page.html;
+5. redirect window.location.href to persistent storage + /$start_page.html;
 
 **Attention:**
 Current version requires internet connection on app startup;  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Tested on android and ios.
 
 Concept:
 1) on startup copy all files from www to PERSISTENT storage. (if not copied before);
+
 2) download config.json from server.
+
 3) compare the version constants in downloaded config.json and local config.json.
 4) if different - download new files from server to PERSISTENT, then override local config.json.
 (download not all files, only new\different which are written in config.json as new. I have a Grunt script that calculates a list of new files.)


### PR DESCRIPTION
Also, the trailing comma in the config.json example caused a sneaky JSON parse error. It said something about all properties needing to be string literals, so I was debugging that but really the trailing comma was telling JSON.parse that we were trying to specify another property. Anyway, removing the comma fixes it!
